### PR TITLE
Use specific client id for this library

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,4 +3,5 @@
  */
 export enum TractiveApi {
   BASE_URL = 'https://graph.tractive.com/4',
+  CLIENT_ID = '6863b6545d3ac2bd948147db',
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -43,7 +43,7 @@ export class AuthService {
           grant_type: 'tractive',
         },
         headers: {
-          'X-Tractive-Client': '625e533dc3c3b41c28a669f0',
+          'X-Tractive-Client': TractiveApi.CLIENT_ID,
           'Content-Type': 'application/json',
         },
       });

--- a/src/modules/hardware/hardware.service.ts
+++ b/src/modules/hardware/hardware.service.ts
@@ -116,7 +116,7 @@ export class HardwareService {
 
       const response = await axios.get(url, {
         headers: {
-          'X-Tractive-Client': '625e533dc3c3b41c28a669f0',
+          'X-Tractive-Client': TractiveApi.CLIENT_ID,
           'Content-Type': 'application/json',
           Authorization: `Bearer ${bearer}`,
         },

--- a/src/modules/location/location.service.ts
+++ b/src/modules/location/location.service.ts
@@ -76,7 +76,7 @@ export class LocationService {
 
       const response = await axios.get(url, {
         headers: {
-          'X-Tractive-Client': '625e533dc3c3b41c28a669f0',
+          'X-Tractive-Client': TractiveApi.CLIENT_ID,
           'Content-Type': 'application/json',
           Authorization: `Bearer ${bearer}`,
         },


### PR DESCRIPTION
This allows Tractive to better understand traffic sources of the API requests observed on their services. The client id is provided and approved by Tractive.

The specific Tractive Client key was created by Tractive specifically for the integration at https://github.com/dominique-boerner/unofficial-tractive-rest-api

Note: This contribution is made in an individual capacity and does not imply any official or unofficial endorsement or support of this project by Tractive. My participation is solely aimed at improving the integration or utilization of his project, and it should not be interpreted as a partnership or confirmation of the project's reliability or security.