### PR TITLE
fix(location,hardware): cache last-known value per tracker id

### DIFF
--- a/src/modules/hardware/hardware.service.spec.ts
+++ b/src/modules/hardware/hardware.service.spec.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import { HardwareService } from './hardware.service';
+import { AuthenticationStore } from '../store/authentication.store';
+import { TrackerDto } from '../../dto/tracker.dto';
+import { TrackerNotFoundException } from '../../exceptions/TrackerNotFoundException';
+import { TractiveHardware } from '../../interfaces/tractive-hardware.interface';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('HardwareService', () => {
+  let service: HardwareService;
+
+  const dto = (trackerId: string): TrackerDto => ({ trackerId } as TrackerDto);
+  const report = (id: string, battery: number): TractiveHardware =>
+    ({ _id: id, battery_level: battery } as unknown as TractiveHardware);
+
+  beforeEach(() => {
+    const store = new AuthenticationStore();
+    store.lastAuthenticationCache = {
+      user_id: 'u',
+      client_id: 'c',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      access_token: 'token',
+    };
+    service = new HardwareService(store);
+    jest.clearAllMocks();
+  });
+
+  it('returns the fetched hardware report for a tracker', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: report('a', 80) });
+
+    await expect(service.getTrackerHardware(dto('tracker-a'))).resolves.toEqual(
+      report('a', 80),
+    );
+  });
+
+  it('does not fall back to another tracker\'s cached report on error', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: report('a', 80) });
+    await service.getTrackerHardware(dto('tracker-a'));
+
+    mockedAxios.get.mockRejectedValueOnce(new Error('tractive down'));
+    await expect(
+      service.getTrackerHardware(dto('tracker-b')),
+    ).rejects.toBeInstanceOf(TrackerNotFoundException);
+  });
+
+  it('falls back to the tracker\'s own last known report on a later error', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: report('a', 80) });
+    await service.getTrackerHardware(dto('tracker-a'));
+
+    mockedAxios.get.mockRejectedValueOnce(new Error('tractive down'));
+    await expect(service.getTrackerHardware(dto('tracker-a'))).resolves.toEqual(
+      report('a', 80),
+    );
+  });
+});

--- a/src/modules/hardware/hardware.service.ts
+++ b/src/modules/hardware/hardware.service.ts
@@ -14,7 +14,12 @@ import { TractiveApi } from '../../constants';
 export class HardwareService {
   private readonly logger = new Logger(HardwareService.name);
 
-  private lastReportCache: TractiveHardware = null;
+  /**
+   * Caches the last known hardware report per tracker id, so a transient error
+   * for one tracker can fall back to that tracker's own last value — never
+   * another tracker's.
+   */
+  private readonly lastReportCache = new Map<string, TractiveHardware>();
 
   constructor(private readonly authenticationStore: AuthenticationStore) {}
 
@@ -122,18 +127,19 @@ export class HardwareService {
         },
       });
 
-      // we cache the last report
-      this.lastReportCache = response.data;
+      // cache the last known report for this tracker
+      this.lastReportCache.set(trackerId, response.data);
 
       this.logger.log(`Tracker hardware report found`);
 
       return response.data;
     } catch (e) {
-      if (this.lastReportCache) {
+      const cachedReport = this.lastReportCache.get(trackerId);
+      if (cachedReport) {
         this.logger.error(
-          `Error while getting tracker hardware report. Return last report instead`,
+          `Error while getting tracker hardware report for '${trackerId}'. Return last known report for this tracker instead`,
         );
-        return this.lastReportCache;
+        return cachedReport;
       }
 
       throw new TrackerNotFoundException();

--- a/src/modules/location/location.service.spec.ts
+++ b/src/modules/location/location.service.spec.ts
@@ -1,0 +1,59 @@
+import axios from 'axios';
+import { LocationService } from './location.service';
+import { AuthenticationStore } from '../store/authentication.store';
+import { TrackerDto } from '../../dto/tracker.dto';
+import { TrackerNotFoundException } from '../../exceptions/TrackerNotFoundException';
+import { TractiveLocation } from '../../interfaces/tractive-location.interface';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('LocationService', () => {
+  let service: LocationService;
+
+  const dto = (trackerId: string): TrackerDto => ({ trackerId } as TrackerDto);
+  const location = (id: string): TractiveLocation =>
+    ({ _id: id, latlong: [1, 2] } as unknown as TractiveLocation);
+
+  beforeEach(() => {
+    const store = new AuthenticationStore();
+    store.lastAuthenticationCache = {
+      user_id: 'u',
+      client_id: 'c',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      access_token: 'token',
+    };
+    service = new LocationService(store);
+    jest.clearAllMocks();
+  });
+
+  it('returns the fetched location for a tracker', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: location('a') });
+
+    await expect(service.getTrackerLocation(dto('tracker-a'))).resolves.toEqual(
+      location('a'),
+    );
+  });
+
+  it('does not fall back to another tracker\'s cached location on error', async () => {
+    // tracker A succeeds and gets cached
+    mockedAxios.get.mockResolvedValueOnce({ data: location('a') });
+    await service.getTrackerLocation(dto('tracker-a'));
+
+    // tracker B fails and has never succeeded -> must NOT return A's data
+    mockedAxios.get.mockRejectedValueOnce(new Error('tractive down'));
+    await expect(
+      service.getTrackerLocation(dto('tracker-b')),
+    ).rejects.toBeInstanceOf(TrackerNotFoundException);
+  });
+
+  it('falls back to the tracker\'s own last known location on a later error', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: location('a') });
+    await service.getTrackerLocation(dto('tracker-a'));
+
+    mockedAxios.get.mockRejectedValueOnce(new Error('tractive down'));
+    await expect(service.getTrackerLocation(dto('tracker-a'))).resolves.toEqual(
+      location('a'),
+    );
+  });
+});

--- a/src/modules/location/location.service.ts
+++ b/src/modules/location/location.service.ts
@@ -14,7 +14,12 @@ import { TractiveApi } from "../../constants";
 export class LocationService {
   private readonly logger = new Logger(LocationService.name);
 
-  private lastLocationCache = null;
+  /**
+   * Caches the last known location per tracker id, so a transient error for one
+   * tracker can fall back to that tracker's own last value — never another
+   * tracker's.
+   */
+  private readonly lastLocationCache = new Map<string, TractiveLocation>();
 
   constructor(private readonly authenticationStore: AuthenticationStore) {}
 
@@ -82,8 +87,8 @@ export class LocationService {
         },
       });
 
-      // we cache the last location
-      this.lastLocationCache = response.data;
+      // cache the last known location for this tracker
+      this.lastLocationCache.set(trackerId, response.data);
 
       this.logger.log(`Tracker location found`);
 
@@ -93,11 +98,12 @@ export class LocationService {
         throw e;
       }
 
-      if (this.lastLocationCache) {
+      const cachedLocation = this.lastLocationCache.get(trackerId);
+      if (cachedLocation) {
         this.logger.error(
-          `Error while getting tracker location. Return last tracker location instead`,
+          `Error while getting tracker location for '${trackerId}'. Return last known location for this tracker instead`,
         );
-        return this.lastLocationCache;
+        return cachedLocation;
       }
 
       throw new TrackerNotFoundException();


### PR DESCRIPTION
Both services kept a single shared cache field, so a transient error for one tracker fell back to whatever tracker was cached last — silently returning another tracker's location or hardware data, which is easy to hit on multi-tracker (comma-separated) requests.

Key the fallback cache by trackerId (Map) so an error for a tracker can only fall back to that tracker's own last value, otherwise it still throws TrackerNotFoundException. The intended "serve last-known-good on a transient Tractive error" resilience is preserved.

Adds unit tests covering the cross-tracker regression for both services.